### PR TITLE
Minor Adjust to DPS Calculation for one-bar Charge Moves

### DIFF
--- a/app/_custom/routes/_site.comprehensive-dps-spreadsheet2+/calc.js
+++ b/app/_custom/routes/_site.comprehensive-dps-spreadsheet2+/calc.js
@@ -183,10 +183,9 @@ function calculateDPS(pokemon, kwargs) {
    if (kwargs.battleMode != "pvp") {
       let FDur = pokemon.fmove.duration / 1000;
       let CDur = pokemon.cmove.duration / 1000;
-      let CDWS = pokemon.cmove.dws / 1000;
 
       if (CE >= 100) {
-         CE = CE + 0.5 * FE + 0.5 * y * CDWS;
+         CE = CE + 0.5 * FE;
       }
 
       let FDPS = FDmg / FDur;


### PR DESCRIPTION
The new raid battle mechanic deducts charge move energy at the beginning of the move animation instead of at Damage Window Start (DWS). Therefore, there's no need to account for additional energy wastage.